### PR TITLE
Encounter Zone improvements/tweaks

### DIFF
--- a/Assets/PreFabs/Characters/Enemy.prefab
+++ b/Assets/PreFabs/Characters/Enemy.prefab
@@ -144,8 +144,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 05ac34e2c435f0046b73486e43318bbc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3832337880142659033
 GameObject:
   m_ObjectHideFlags: 0
@@ -311,8 +311,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f90ed41905425ec4d95e7dee12a1cac4, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   ActorType: 0
   Stats: {fileID: 11400000, guid: 2d4e21e94621b6743a5338596fd40776, type: 2}
   Waypoints: []
@@ -327,8 +327,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76f0d07869b7ad747b46fdf13457c82e, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   <ObjectId>k__BackingField: Enemy-0.1013
   _isInvulnerable: 0
   _maxHealth: 50
@@ -370,7 +370,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
-  m_WarningMessage:
+  m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0

--- a/Assets/PreFabs/Characters/Player.prefab
+++ b/Assets/PreFabs/Characters/Player.prefab
@@ -175,7 +175,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 76f0d07869b7ad747b46fdf13457c82e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <ObjectId>k__BackingField: Player-28,3024
+  <ObjectId>k__BackingField: Player-28.3024
   _isInvulnerable: 0
   _maxHealth: 100
 --- !u!95 &8530993155805609580

--- a/Assets/PreFabs/Interaction/DoorInteractionPoint.prefab
+++ b/Assets/PreFabs/Interaction/DoorInteractionPoint.prefab
@@ -47,7 +47,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b7410dd48c7ef63c690e526e711552ef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <ObjectId>k__BackingField: DoorInteractionPoint-2,6633
+  <ObjectId>k__BackingField: DoorInteractionPoint-2.6633
   InteractionRange: 2
   AutoTrigger: 0
   SingleUse: 0

--- a/Assets/PreFabs/Interaction/Room Trigger.prefab
+++ b/Assets/PreFabs/Interaction/Room Trigger.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 6972347098002444416}
   - component: {fileID: 4109000722959676931}
   - component: {fileID: 8026613792816804491}
-  m_Layer: 0
+  m_Layer: 2
   m_Name: Room Trigger
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -91,6 +91,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <ObjectId>k__BackingField: Room Trigger-0
-  _borders: []
+  _addEnemiesDynamic: 1
+  _borders:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   _enemies: []
   _isCleared: 0

--- a/Assets/Scripts/Libraries/ScriptableObjectId.cs
+++ b/Assets/Scripts/Libraries/ScriptableObjectId.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEditor;
 using UnityEngine;
-	
+
 public class ScriptableObjectIdAttribute : PropertyAttribute { }
 
 #if UNITY_EDITOR

--- a/Assets/Scripts/Managers/SceneStuff/RoomTrigger.cs
+++ b/Assets/Scripts/Managers/SceneStuff/RoomTrigger.cs
@@ -4,13 +4,19 @@ using UnityEngine;
 public class RoomTrigger : MonoBehaviour, ISaveable {
 
 	[field: SerializeField, Header("Object information")] public string ObjectId { get; private set; }
-
+	[Header("Settings")]
+	[SerializeField] private bool _addEnemiesDynamic = true;
 	[SerializeField] private List<GameObject> _borders;
 	[SerializeField] private List<GameObject> _enemies;
 	[SerializeField] private bool _isCleared;
 
+
 	private void OnTriggerEnter2D(Collider2D other) {
-		if (other.tag == "Player" && _enemies.Count > 0) {
+		if (other.CompareTag("Enemy") && _addEnemiesDynamic) {
+			_enemies.Add(other.gameObject);
+		}
+
+		if (other.CompareTag("Player") && _enemies.Count > 0) {
 			foreach (GameObject border in _borders) {
 				border.SetActive(true);
 				EventBus.Instance.TriggerEvent(EventType.INTERACT_TOGGLE, false);
@@ -19,11 +25,8 @@ public class RoomTrigger : MonoBehaviour, ISaveable {
 	}
 
 	private void OnTriggerExit2D(Collider2D other) {
-		if (other.tag == "Enemy") {
+		if (other.CompareTag("Enemy")) {
 			_enemies.Remove(other.gameObject);
-			if (_enemies.Count <= 0) {
-				UnlockArea();
-			}
 		}
 	}
 
@@ -35,6 +38,12 @@ public class RoomTrigger : MonoBehaviour, ISaveable {
 				toremove.Add(enemy);
 			}
 			_enemies.RemoveAll(x => toremove.Contains(x));
+		}
+	}
+
+	private void Update() {
+		if (_enemies.Count <= 0) {
+			UnlockArea();
 		}
 	}
 


### PR DESCRIPTION
What it says in the commit.

Added dynamic enemy detection to the RoomTrigger collider so enemies do not need to be specified beforehand (w/toggle to disable it)
Moved the Unlock check and method call to Update instead of OnTrigger to avoid accessing objects after destruction.